### PR TITLE
Added support for new kubernetes ingress syntax, pathType

### DIFF
--- a/docs/pages/configuration/ingress.mdx
+++ b/docs/pages/configuration/ingress.mdx
@@ -57,6 +57,27 @@ ingress:
     path: /login
 ```
 
+### `pathType`
+Since v1.18.0 of kubernetes each path in an Ingress is required to have a corresponding [path type](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types)
+
+There are three supported path types:
+- `ImplementationSpecific`: With this path type, matching is up to the IngressClass. Implementations can treat this as a separate pathType or treat it identically to Prefix or Exact path types.
+- `Exact`: Matches the URL path exactly and with case sensitivity.
+- `Prefix`: Matches based on a URL path prefix split by /. Matching is case sensitive and done on a path element by element basis. A path element refers to the list of labels in the path split by the / separator. A request is a match for path p if every p is an element-wise prefix of p of the request path.
+
+#### Example: Defining Ingress Path type
+```yaml
+containers:
+- image: dscr.io/${DEVSPACE_USERNAME}/appfrontend
+service:
+  ports:
+  - port: 3000
+ingress:
+  rules:
+  - host: my-static-host.tld
+    path: /login
+    pathType: Prefix
+```
 
 ### `servicePort`
 The `servicePort` option expects an integer stating the port of the service to which the traffic should be routed for the hostname stated in `host`.

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -18,7 +18,13 @@
   {{- end }}
 {{- end }}
 {{- end }}
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   {{- if $.Values.ingress.name }}
@@ -73,29 +79,46 @@ spec:
   {{- end }}
   rules:
   {{- range $ingressRuleIndex, $ingressRule := $.Values.ingress.rules }}
+
+  {{- $svcPort := 0 }}
+  {{- if $ingressRule.servicePort }}
+  {{- $svcPort = $ingressRule.servicePort -}}
+  {{- else }}
+  {{- $svcPort = (index $.Values.service.ports 0).port -}}
+  {{- end }}
+
+  {{- $svcName := "" }}
+  {{- if $ingressRule.serviceName }}
+  {{- $svcName = $ingressRule.serviceName -}}
+  {{- else }}
+  {{- if $.Values.service.name }}
+  {{- $svcName = $.Values.service.name -}}
+  {{- else }}
+  {{- $svcName = $.Release.Name -}}
+  {{- end }}
+  {{- end }}
   - host: {{ $ingressRule.host | quote }}
     http:
       paths:
       - backend:
-          {{- if $ingressRule.serviceName }}
-          serviceName: {{ $ingressRule.serviceName | quote }}
-          {{- else }}
-          {{- if $.Values.service.name }}
-          serviceName: {{ $.Values.service.name | quote }}
-          {{- else }}
-          serviceName: {{ $.Release.Name | quote }}
-          {{- end }}
-          {{- end }}
-          {{- if $ingressRule.servicePort }}
-          servicePort: {{ $ingressRule.servicePort }}
-          {{- else }}
-          servicePort: {{ (index $.Values.service.ports 0).port }}
-          {{- end }}
+        {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $svcName | quote }}
+            port:
+              number: {{ $svcPort }}
+        {{- else}}
+          serviceName: {{ $svcName }}
+          servicePort: {{ $svcPort }}
+        {{- end }}
         {{- if $ingressRule.path }}
         path: {{ $ingressRule.path | quote }}
         {{- else }}
         path: /
         {{- end }}
+        {{- if and $ingressRule.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+        pathType: {{ $ingressRule.pathType | quote }}
+        {{- end }}
+        
   {{- end }}
   {{- if ne (printf "%s" $tlsSecretName) "" }}
   tls:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -18,9 +18,9 @@
   {{- end }}
 {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress"}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion -}}
+{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -101,12 +101,12 @@ spec:
     http:
       paths:
       - backend:
-        {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+        {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress"}}
           service:
             name: {{ $svcName | quote }}
             port:
               number: {{ $svcPort }}
-        {{- else}}
+        {{- else }}
           serviceName: {{ $svcName }}
           servicePort: {{ $svcPort }}
         {{- end }}

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -11,6 +11,7 @@ ingress:
   tls: true
   rules:
   - host: some-hostname.tld
+    pathType: Prefix
 volumes:
 - name: test-data
   size: "2Gi"


### PR DESCRIPTION
Hello everyone.
When i tried to use component-chart with minikube(1.20.0) with enabled ingress addon and fresh kubernetes() i got an error:

`[fatal]  error deploying: error deploying <WIPED>: Unable to deploy helm chart: error during 'helm upgrade <WIPED>; --values /tmp/635534093 --install --kube-context minikube': W0610 17:09:33.468780  101725 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 IngressW0610 17:09:33.472288  101725 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`

So i decided to fix this problem and created this PR.
FYI: Some code copypasted from helm [default Ingress template](https://github.com/helm/helm/blob/main/pkg/lint/rules/testdata/v3-fail/templates/ingress.yaml).

Please review carefully, maybe i forgot something