### PR TITLE
fix: datatype of targetAverageUtilization for Horizontal Pod Autoscaling

### DIFF
--- a/templates/pod-autoscaling.yaml
+++ b/templates/pod-autoscaling.yaml
@@ -62,6 +62,7 @@ spec:
       name: memory
       targetAverageUtilization: {{ $.Values.autoScaling.horizontal.averageRelativeMemory | int }}
   {{- end }}
+
 ---
 {{- end }}
 {{- end }}

--- a/templates/pod-autoscaling.yaml
+++ b/templates/pod-autoscaling.yaml
@@ -48,7 +48,7 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ $.Values.autoScaling.horizontal.averageRelativeCPU }}
+      targetAverageUtilization: {{ $.Values.autoScaling.horizontal.averageRelativeCPU | int }}
   {{- end }}
   {{- if $.Values.autoScaling.horizontal.averageMemory }}
   - type: Resource
@@ -60,7 +60,7 @@ spec:
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: {{ $.Values.autoScaling.horizontal.averageRelativeMemory | quote }}
+      targetAverageUtilization: {{ $.Values.autoScaling.horizontal.averageRelativeMemory | int }}
   {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
For Horizontal Pod Autoscaling, 

While using autoscaling based on targetAverageUtilization, in was facing this issue in DevSpace version : 6.0.1 

Input:
```yaml
  replicas: 1
  autoScaling:
    horizontal:  
      maxReplicas: 3
      averageRelativeMemory: 40
```

Error:
```
ValidationError(HorizontalPodAutoscaler.spec.metrics[0].resource.targetAverageUtilization): invalid type for io.k8s.api.autoscaling.v2beta1.ResourceMetricSource.targetAverageUtilization: got "string", expected "integer"
```

References:
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale

targetAverageUtilization requires integer, but string was been given, so have prvided fixes for that.