### PR TITLE
fix: surge/unavailable values should not be quoted

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -39,8 +39,8 @@ spec:
     {{- if $.Values.rollingUpdate.enabled }}
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ $.Values.rollingUpdate.maxSurge | default "25%" | quote }}
-      maxUnavailable: {{ $.Values.rollingUpdate.maxUnavailable | default "0%" | quote }}
+      maxSurge: {{ $.Values.rollingUpdate.maxSurge | default "25%" }}
+      maxUnavailable: {{ $.Values.rollingUpdate.maxUnavailable | default "0%" }}
     {{- else }}
     type: Recreate
     {{- end }}


### PR DESCRIPTION
/kind bugfix

resolves https://github.com/devspace-sh/devspace/issues/2517
Closes ENG-938

Right now we're using `quote` in the `maxSurge` and `maxUnavailable` values
This works ok with % values, but not with pure integers

Pure integers are expected to work, as by k8s documentation: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#proportional-scaling

This commit removes the `quote`, testing it results in `devspace` working also with integer values in `maxSurge/maxUnavailable`