### PR TITLE
allow disable certmanager

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -49,6 +49,7 @@ metadata:
     {{- end }}
   annotations:
     "helm.sh/chart": "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    {{- if $.Values.ingress.certmanager }}
     {{- $addClusterIssuer := true }}
     {{- $addIngressClass := true }}
     {{- range $annotationName, $annotationValue := $.Values.ingress.annotations }}
@@ -68,6 +69,7 @@ metadata:
     {{- if $addIngressClass }}
     acme.cert-manager.io/http01-ingress-class: {{ $.Values.ingress.ingressClass | default "nginx" | quote }}
     certmanager.k8s.io/http01-ingress-class: {{ $.Values.ingress.ingressClass | default "nginx" | quote }}
+    {{- end }}
     {{- end }}
     {{- end }}
 spec:

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,7 @@ ingress:
   disabled: false
   labels: {}
   annotations: {}
+  certmanager: true
   rules: []
 
 # Define persistent volumes here


### PR DESCRIPTION
I think cert issuer can be a default option to manage HTTPS cert, but sometimes we have our own cert to use, set `ingress.certmanager=false` fix this