### PR TITLE
Fix Ingress apiVersion

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -19,13 +19,7 @@
   {{- end }}
 {{- end }}
 {{- end }}
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress"}}
 apiVersion: networking.k8s.io/v1
-{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   {{- if $.Values.ingress.name }}


### PR DESCRIPTION
The use of Capabilities in Helm Chart templates is currently not supported by Kustomize (see [here](https://github.com/kubernetes-sigs/kustomize/issues/5112)).

The use of Capabilities in the Ingress template should not be necessary as the apiVersion `networking.k8s.io/v1` has been supported since K8s 1.19 (see [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)).

This PR removes the templating around the Ingress apiVersion to fix the apiVersion to `networking.k8s.io/v1` and allows Component Chart to be used as part of a Kustomize deployment (as defined [here](https://kubectl.docs.kubernetes.io/references/kustomize/builtins/#_helmchartinflationgenerator_)).