### PR TITLE
Support dual stack services

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -37,7 +37,7 @@ spec:
   healthCheckNodePort: {{ $.Values.service.healthCheckNodePort }}
   {{- end }}
   {{- if $.Values.service.ipFamily }}
-  ipFamily: {{ $.Values.service.ipFamily }}
+  ipFamilyPolicy: {{ $.Values.service.ipFamily }}
   {{- end }}
   {{- if $.Values.service.loadBalancerIP }}
   loadBalancerIP: {{ $.Values.service.loadBalancerIP }}


### PR DESCRIPTION
This keeps ipFamily in the component chart and translates it to `ipFamilyPolicy` to allow dual stack deployments.

Closes #107 