### PR TITLE
Docs: Outdated ingress property

### DIFF
--- a/docs/pages/configuration/ingress.mdx
+++ b/docs/pages/configuration/ingress.mdx
@@ -176,12 +176,12 @@ ingress:
   - host: my-static-host2.tld
 ```
 
-## `ingressClass`
-The `ingressClass` option expects a string with a Kubernetes ingress class used for a cert-manager annotation.
+## `ingressClassName`
+The `ingressClassName` option expects a string with a Kubernetes ingress class used for a cert-manager annotation.
 
-#### Default Value For `ingressClass`
+#### Default Value For `ingressClassName`
 ```yaml
-ingressClass: nginx
+ingressClassName: ''
 ```
 
 #### Example: Custom Ingress Class
@@ -192,7 +192,7 @@ service:
   ports:
   - port: 3000
 ingress:
-  ingressClass: traefik
+  ingressClassName: traefik
   tls: true
   rules:
   - host: my-static-host.tld


### PR DESCRIPTION
The `ingressClass` property is outdated and should be `ingressClassName` now:

https://github.com/loft-sh/component-chart/blob/e974dae5470e5dbb873e799db0b7f265f2f2780f/templates/ingress.yaml#L78-L80

No default values are defined for it:

https://github.com/loft-sh/component-chart/blob/e974dae5470e5dbb873e799db0b7f265f2f2780f/values.yaml#L19-L24